### PR TITLE
強制的にリセットされていた不具合の解消

### DIFF
--- a/src/Assets/Scripts/PlayDirector.cs
+++ b/src/Assets/Scripts/PlayDirector.cs
@@ -127,7 +127,6 @@ public class PlayDirector : MonoBehaviour
     class GameOverState : IState
     {
         public IState.E_State Initialize(PlayDirector parent) {
-            SceneManager.LoadScene(0);
             return IState.E_State.Unchanged;
         }
         public IState.E_State Update(PlayDirector parent) { return IState.E_State.Unchanged; }


### PR DESCRIPTION
GameOverState の初期化時に強制的にアプリケーションを再起動していたので、修正しました。
これでゲームオーバー画面が表示されると思います。